### PR TITLE
add gstreamer lib, reconfigure chromaprint cmake options to install fpcalc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,19 @@ RUN \
 	ffmpeg \
 	ffmpeg-libs \
 	gdbm \
+	gstreamer1 \
 	jpeg \
 	lame \
 	libffi \
 	libpng \
 	nano \
 	openjpeg \
+	py-gobject \
 	py-pip \
 	python \
 	py-unidecode \
 	sqlite-libs \
+	tar \
 	wget && \
 
 # install build packages
@@ -60,7 +63,7 @@ RUN \
 	/tmp/chromaprint && \
  cd /tmp/chromaprint && \
  cmake \
-	-DBUILD_EXAMPLES=ON . \
+	-DBUILD_TOOLS=ON \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX:PATH=/usr && \
  make && \

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See [Beets][beetsurl] for more info.
 
 ## Versions
 
++ **07.12.16:** Edit cmake options for chromaprint, should now build and install fpcalc, add gstreamer lib
 + **14.10.16:** Add version layer information.
 + **01.10.16:** Add nano and editor variable -
 to allow editing of the config from the container command line.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ change chromaprint cmake options, now builds and installs fpcalc
+ add gstreamer and py-gobject packages as per [beets documentation on chromaprint](http://beets.readthedocs.io/en/v1.4.1/plugins/chroma.html)